### PR TITLE
Add string conversion to similar string types

### DIFF
--- a/mirror_test.go
+++ b/mirror_test.go
@@ -26,6 +26,28 @@ func _PerformTest(name string, source, destination interface{}, hasError bool, t
 	})
 }
 
+func _PerformTestSmart(name string, source, destination interface{}, expect interface{}, hasError bool, t *testing.T) {
+	t.Run(name, func(t *testing.T) {
+		err := SmartMirror(source, destination)
+		if err != nil {
+			if !hasError {
+				t.Errorf("Got an error %s", err.Error())
+			} else {
+				return
+			}
+		} else if err == nil && hasError {
+			t.Error("Expecting error but got nothing")
+		}
+
+		source = reflect.ValueOf(source).Elem().Interface()
+		destination = reflect.ValueOf(destination).Elem().Interface()
+		expect = reflect.ValueOf(expect).Elem().Interface()
+		if !reflect.DeepEqual(expect, destination) {
+			t.Errorf("Expected %v but got %v", expect, destination)
+		}
+	})
+}
+
 func TestPrimitive(t *testing.T) {
 
 	inInt := -100

--- a/string.go
+++ b/string.go
@@ -15,7 +15,7 @@ func _HandleString(source, dest reflect.Value, sourceKind, destKind reflect.Kind
 	} else {
 		switch sourceKind {
 		case reflect.String:
-			dest.Set(source)
+			dest.Set(source.Convert(dest.Type()))
 		case reflect.Int, reflect.Uint, reflect.Float32, reflect.Float64, reflect.Bool:
 			dest.SetString(fmt.Sprint(source.Interface()))
 		default:

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,72 @@
+package mirror
+
+import "testing"
+
+type MyString string
+
+func TestPrimitiveStringToString(t *testing.T) {
+
+	testData := []struct {
+		Name        string
+		Source      string
+		Destination string
+		HasError    bool
+	}{
+		{
+			"StringToString",
+			"test",
+			"",
+			false,
+		},
+	}
+
+	for _, val := range testData {
+		_PerformTest(val.Name, &val.Source, &val.Destination, val.HasError, t)
+	}
+}
+
+func TestPrimitiveStringToMyString(t *testing.T) {
+
+	testData := []struct {
+		Name        string
+		Source      string
+		Destination MyString
+		Expect      MyString
+		HasError    bool
+	}{
+		{
+			"StringToMyString",
+			"test",
+			"",
+			"test",
+			false,
+		},
+	}
+
+	for _, val := range testData {
+		_PerformTestSmart(val.Name, &val.Source, &val.Destination, &val.Expect, val.HasError, t)
+	}
+}
+
+func TestPrimitiveMyStringToString(t *testing.T) {
+
+	testData := []struct {
+		Name        string
+		Source      MyString
+		Destination string
+		Expect      string
+		HasError    bool
+	}{
+		{
+			"MyStringToString",
+			"test",
+			"",
+			"test",
+			false,
+		},
+	}
+
+	for _, val := range testData {
+		_PerformTestSmart(val.Name, &val.Source, &val.Destination, &val.Expect, val.HasError, t)
+	}
+}


### PR DESCRIPTION
Add ability to convert types based on string type

For example


type MyString string

type Person struct {
   Name MyString
}

type Organizm struct {
   Name string
}

p := &Person{Name:"person"}
o := &Organizm{}
SmartMirror(p, o)